### PR TITLE
fontconfig: Use Fira Code instead of Fira Mono

### DIFF
--- a/fontconfig/defaults/main.yml
+++ b/fontconfig/defaults/main.yml
@@ -3,4 +3,8 @@ config_directory: "{{ config_home }}/fontconfig"
 config_file: fonts.conf
 dependencies:
   - fontconfig
-  - ttf-fira-mono
+  - otf-fira-code
+
+fonts:
+  - family: monospace
+    name: Fira Code

--- a/fontconfig/templates/fonts.conf
+++ b/fontconfig/templates/fonts.conf
@@ -1,4 +1,6 @@
+{% for font in fonts %}
 <alias>
-  <family>monospace</family>
-  <prefer><family>Fira Mono</family></prefer>
+  <family>{{ font.family }}</family>
+  <prefer><family>{{ font.name }}</family></prefer>
 </alias>
+{% endfor %}


### PR DESCRIPTION
Fira Code is a monospaced font with programming ligatures. It is based
on Fira Mono and therefore very similar.

Ligatures are an interesting feature, as they visually change certain
character combinations to symbols, without changing the underlying
characters themselves. Setting it as the default font through fontconfig
will enable all application to use this font. Not all application
support ligatures however, but it seems that they will simply ignore
this, making it safe to set globally.