### PR TITLE
fish: set SHELL to fish binary path

### DIFF
--- a/nix/home-manager/programs/fish/shell_init.fish
+++ b/nix/home-manager/programs/fish/shell_init.fish
@@ -6,3 +6,7 @@ fish_add_path --global "$HOME/.cargo/bin"
 
 # Add directory for Nix profile
 fish_add_path --global "$HOME/.nix-profile/bin"
+
+# Set SHELL to the Fish binary path since Fish is always started from Bash
+# and $SHELL would otherwise inherit /bin/bash
+set -gx SHELL (which fish)

--- a/nix/home-manager/programs/fish/shell_init.fish
+++ b/nix/home-manager/programs/fish/shell_init.fish
@@ -7,6 +7,12 @@ fish_add_path --global "$HOME/.cargo/bin"
 # Add directory for Nix profile
 fish_add_path --global "$HOME/.nix-profile/bin"
 
+set --global --export SHELL (which fish)
+>>>>>>> c70f380 (fish: use long-form options for set command)
+=======
 # Set SHELL to the Fish binary path since Fish is always started from Bash
 # and $SHELL would otherwise inherit /bin/bash
-set -gx SHELL (which fish)
+set --global --export SHELL (which fish)
+=======
+set --global --export SHELL (which fish)
+>>>>>>> c70f380 (fish: use long-form options for set command)


### PR DESCRIPTION
Since Fish is always started from a Bash environment (via Nix Home Manager), the $SHELL environment variable inherits /bin/bash from the parent process. This change sets SHELL to the actual Fish binary path using 'which fish' in the shell initialization, ensuring $SHELL correctly reflects the current shell.