### PR TITLE
fish: set SHELL to fish binary path using long-form options

### DIFF
--- a/nix/home-manager/programs/fish/shell_init.fish
+++ b/nix/home-manager/programs/fish/shell_init.fish
@@ -6,3 +6,7 @@ fish_add_path --global "$HOME/.cargo/bin"
 
 # Add directory for Nix profile
 fish_add_path --global "$HOME/.nix-profile/bin"
+
+# Set SHELL to the Fish binary path since Fish is always started from Bash
+# and $SHELL would otherwise inherit /bin/bash
+set --global --export SHELL (which fish)


### PR DESCRIPTION
Set SHELL to the Fish binary path since Fish is always started from Bash and $SHELL would otherwise inherit /bin/bash. Uses long-form options for the set command.